### PR TITLE
Implement Acceptance Criteria management

### DIFF
--- a/.kiro/specs/product-requirements-management/tasks.md
+++ b/.kiro/specs/product-requirements-management/tasks.md
@@ -46,7 +46,7 @@
   - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 1.6_
   - commit, push and make pull request
 
-- [-] 7. Implement User Story management functionality
+- [x] 7. Implement User Story management functionality
   - Create a git branch for feature
   - Create a git branch for feature
   - Create UserStory service with CRUD operations
@@ -59,7 +59,7 @@
   - commit, push and make pull request
 
 
-- [ ] 8. Implement Acceptance Criteria management
+- [-] 8. Implement Acceptance Criteria management
   - Create a git branch for feature
   - Create AcceptanceCriteria service with CRUD operations
   - Implement AcceptanceCriteria API endpoints

--- a/internal/handlers/acceptance_criteria_handler.go
+++ b/internal/handlers/acceptance_criteria_handler.go
@@ -1,0 +1,307 @@
+package handlers
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"product-requirements-management/internal/models"
+	"product-requirements-management/internal/service"
+)
+
+// AcceptanceCriteriaHandler handles HTTP requests for acceptance criteria operations
+type AcceptanceCriteriaHandler struct {
+	acceptanceCriteriaService service.AcceptanceCriteriaService
+}
+
+// NewAcceptanceCriteriaHandler creates a new acceptance criteria handler instance
+func NewAcceptanceCriteriaHandler(acceptanceCriteriaService service.AcceptanceCriteriaService) *AcceptanceCriteriaHandler {
+	return &AcceptanceCriteriaHandler{
+		acceptanceCriteriaService: acceptanceCriteriaService,
+	}
+}
+
+// CreateAcceptanceCriteria handles POST /api/v1/user-stories/:id/acceptance-criteria
+func (h *AcceptanceCriteriaHandler) CreateAcceptanceCriteria(c *gin.Context) {
+	userStoryIDParam := c.Param("id")
+	
+	// Parse user story ID
+	userStoryID, err := uuid.Parse(userStoryIDParam)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Invalid user story ID format",
+		})
+		return
+	}
+
+	var req service.CreateAcceptanceCriteriaRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Invalid request body",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	// Set user story ID from URL parameter
+	req.UserStoryID = userStoryID
+
+	acceptanceCriteria, err := h.acceptanceCriteriaService.CreateAcceptanceCriteria(req)
+	if err != nil {
+		switch {
+		case errors.Is(err, service.ErrUserStoryNotFound):
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": "User story not found",
+			})
+		case errors.Is(err, service.ErrUserNotFound):
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": "Author not found",
+			})
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "Failed to create acceptance criteria",
+			})
+		}
+		return
+	}
+
+	c.JSON(http.StatusCreated, acceptanceCriteria)
+}
+
+// GetAcceptanceCriteria handles GET /api/v1/acceptance-criteria/:id
+func (h *AcceptanceCriteriaHandler) GetAcceptanceCriteria(c *gin.Context) {
+	idParam := c.Param("id")
+	
+	// Try to parse as UUID first, then as reference ID
+	var acceptanceCriteria *models.AcceptanceCriteria
+	var err error
+	
+	if id, parseErr := uuid.Parse(idParam); parseErr == nil {
+		acceptanceCriteria, err = h.acceptanceCriteriaService.GetAcceptanceCriteriaByID(id)
+	} else {
+		acceptanceCriteria, err = h.acceptanceCriteriaService.GetAcceptanceCriteriaByReferenceID(idParam)
+	}
+
+	if err != nil {
+		if errors.Is(err, service.ErrAcceptanceCriteriaNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{
+				"error": "Acceptance criteria not found",
+			})
+		} else {
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "Failed to get acceptance criteria",
+			})
+		}
+		return
+	}
+
+	c.JSON(http.StatusOK, acceptanceCriteria)
+}
+
+// UpdateAcceptanceCriteria handles PUT /api/v1/acceptance-criteria/:id
+func (h *AcceptanceCriteriaHandler) UpdateAcceptanceCriteria(c *gin.Context) {
+	idParam := c.Param("id")
+	
+	// Parse ID (UUID only for updates)
+	id, err := uuid.Parse(idParam)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Invalid acceptance criteria ID format",
+		})
+		return
+	}
+
+	var req service.UpdateAcceptanceCriteriaRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Invalid request body",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	acceptanceCriteria, err := h.acceptanceCriteriaService.UpdateAcceptanceCriteria(id, req)
+	if err != nil {
+		switch {
+		case errors.Is(err, service.ErrAcceptanceCriteriaNotFound):
+			c.JSON(http.StatusNotFound, gin.H{
+				"error": "Acceptance criteria not found",
+			})
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "Failed to update acceptance criteria",
+			})
+		}
+		return
+	}
+
+	c.JSON(http.StatusOK, acceptanceCriteria)
+}
+
+// DeleteAcceptanceCriteria handles DELETE /api/v1/acceptance-criteria/:id
+func (h *AcceptanceCriteriaHandler) DeleteAcceptanceCriteria(c *gin.Context) {
+	idParam := c.Param("id")
+	
+	// Parse ID (UUID only for deletes)
+	id, err := uuid.Parse(idParam)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Invalid acceptance criteria ID format",
+		})
+		return
+	}
+
+	// Check for force parameter
+	force := c.Query("force") == "true"
+
+	err = h.acceptanceCriteriaService.DeleteAcceptanceCriteria(id, force)
+	if err != nil {
+		switch {
+		case errors.Is(err, service.ErrAcceptanceCriteriaNotFound):
+			c.JSON(http.StatusNotFound, gin.H{
+				"error": "Acceptance criteria not found",
+			})
+		case errors.Is(err, service.ErrAcceptanceCriteriaHasRequirements):
+			c.JSON(http.StatusConflict, gin.H{
+				"error": "Acceptance criteria has associated requirements and cannot be deleted",
+				"hint": "Use force=true to delete with dependencies",
+			})
+		case errors.Is(err, service.ErrUserStoryMustHaveAcceptanceCriteria):
+			c.JSON(http.StatusConflict, gin.H{
+				"error": "User story must have at least one acceptance criteria",
+				"hint": "Create another acceptance criteria before deleting this one, or use force=true",
+			})
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "Failed to delete acceptance criteria",
+			})
+		}
+		return
+	}
+
+	c.JSON(http.StatusNoContent, nil)
+}
+
+// ListAcceptanceCriteria handles GET /api/v1/acceptance-criteria
+func (h *AcceptanceCriteriaHandler) ListAcceptanceCriteria(c *gin.Context) {
+	var filters service.AcceptanceCriteriaFilters
+
+	// Parse query parameters
+	if userStoryID := c.Query("user_story_id"); userStoryID != "" {
+		if id, err := uuid.Parse(userStoryID); err == nil {
+			filters.UserStoryID = &id
+		}
+	}
+
+	if authorID := c.Query("author_id"); authorID != "" {
+		if id, err := uuid.Parse(authorID); err == nil {
+			filters.AuthorID = &id
+		}
+	}
+
+	if orderBy := c.Query("order_by"); orderBy != "" {
+		filters.OrderBy = orderBy
+	}
+
+	if limit := c.Query("limit"); limit != "" {
+		if l, err := strconv.Atoi(limit); err == nil && l > 0 {
+			filters.Limit = l
+		}
+	}
+
+	if offset := c.Query("offset"); offset != "" {
+		if o, err := strconv.Atoi(offset); err == nil && o >= 0 {
+			filters.Offset = o
+		}
+	}
+
+	acceptanceCriteria, err := h.acceptanceCriteriaService.ListAcceptanceCriteria(filters)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "Failed to list acceptance criteria",
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"acceptance_criteria": acceptanceCriteria,
+		"count": len(acceptanceCriteria),
+	})
+}
+
+// GetAcceptanceCriteriaByUserStory handles GET /api/v1/user-stories/:id/acceptance-criteria
+func (h *AcceptanceCriteriaHandler) GetAcceptanceCriteriaByUserStory(c *gin.Context) {
+	userStoryIDParam := c.Param("id")
+	
+	// Try to parse as UUID first, then as reference ID
+	var userStoryID uuid.UUID
+	var err error
+	
+	if id, parseErr := uuid.Parse(userStoryIDParam); parseErr == nil {
+		userStoryID = id
+	} else {
+		// For reference ID, we need to resolve it first
+		// This would require the user story service, but for now we'll return an error
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Please use UUID for user story ID in this endpoint",
+		})
+		return
+	}
+
+	acceptanceCriteria, err := h.acceptanceCriteriaService.GetAcceptanceCriteriaByUserStory(userStoryID)
+	if err != nil {
+		switch {
+		case errors.Is(err, service.ErrUserStoryNotFound):
+			c.JSON(http.StatusNotFound, gin.H{
+				"error": "User story not found",
+			})
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "Failed to get acceptance criteria for user story",
+			})
+		}
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"acceptance_criteria": acceptanceCriteria,
+		"count": len(acceptanceCriteria),
+	})
+}
+
+// GetAcceptanceCriteriaByAuthor handles GET /api/v1/users/:id/acceptance-criteria
+func (h *AcceptanceCriteriaHandler) GetAcceptanceCriteriaByAuthor(c *gin.Context) {
+	authorIDParam := c.Param("id")
+	
+	// Parse author ID (UUID only)
+	authorID, err := uuid.Parse(authorIDParam)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Invalid author ID format",
+		})
+		return
+	}
+
+	acceptanceCriteria, err := h.acceptanceCriteriaService.GetAcceptanceCriteriaByAuthor(authorID)
+	if err != nil {
+		switch {
+		case errors.Is(err, service.ErrUserNotFound):
+			c.JSON(http.StatusNotFound, gin.H{
+				"error": "Author not found",
+			})
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{
+				"error": "Failed to get acceptance criteria for author",
+			})
+		}
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"acceptance_criteria": acceptanceCriteria,
+		"count": len(acceptanceCriteria),
+	})
+}

--- a/internal/handlers/acceptance_criteria_handler_test.go
+++ b/internal/handlers/acceptance_criteria_handler_test.go
@@ -1,0 +1,503 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"product-requirements-management/internal/models"
+	"product-requirements-management/internal/service"
+)
+
+// MockAcceptanceCriteriaService is a mock implementation of AcceptanceCriteriaService
+type MockAcceptanceCriteriaService struct {
+	mock.Mock
+}
+
+func (m *MockAcceptanceCriteriaService) CreateAcceptanceCriteria(req service.CreateAcceptanceCriteriaRequest) (*models.AcceptanceCriteria, error) {
+	args := m.Called(req)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.AcceptanceCriteria), args.Error(1)
+}
+
+func (m *MockAcceptanceCriteriaService) GetAcceptanceCriteriaByID(id uuid.UUID) (*models.AcceptanceCriteria, error) {
+	args := m.Called(id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.AcceptanceCriteria), args.Error(1)
+}
+
+func (m *MockAcceptanceCriteriaService) GetAcceptanceCriteriaByReferenceID(referenceID string) (*models.AcceptanceCriteria, error) {
+	args := m.Called(referenceID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.AcceptanceCriteria), args.Error(1)
+}
+
+func (m *MockAcceptanceCriteriaService) UpdateAcceptanceCriteria(id uuid.UUID, req service.UpdateAcceptanceCriteriaRequest) (*models.AcceptanceCriteria, error) {
+	args := m.Called(id, req)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.AcceptanceCriteria), args.Error(1)
+}
+
+func (m *MockAcceptanceCriteriaService) DeleteAcceptanceCriteria(id uuid.UUID, force bool) error {
+	args := m.Called(id, force)
+	return args.Error(0)
+}
+
+func (m *MockAcceptanceCriteriaService) ListAcceptanceCriteria(filters service.AcceptanceCriteriaFilters) ([]models.AcceptanceCriteria, error) {
+	args := m.Called(filters)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]models.AcceptanceCriteria), args.Error(1)
+}
+
+func (m *MockAcceptanceCriteriaService) GetAcceptanceCriteriaByUserStory(userStoryID uuid.UUID) ([]models.AcceptanceCriteria, error) {
+	args := m.Called(userStoryID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]models.AcceptanceCriteria), args.Error(1)
+}
+
+func (m *MockAcceptanceCriteriaService) GetAcceptanceCriteriaByAuthor(authorID uuid.UUID) ([]models.AcceptanceCriteria, error) {
+	args := m.Called(authorID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]models.AcceptanceCriteria), args.Error(1)
+}
+
+func (m *MockAcceptanceCriteriaService) ValidateUserStoryHasAcceptanceCriteria(userStoryID uuid.UUID) error {
+	args := m.Called(userStoryID)
+	return args.Error(0)
+}
+
+func setupAcceptanceCriteriaTestRouter() (*gin.Engine, *MockAcceptanceCriteriaService) {
+	gin.SetMode(gin.TestMode)
+	
+	mockService := new(MockAcceptanceCriteriaService)
+	handler := NewAcceptanceCriteriaHandler(mockService)
+	
+	router := gin.New()
+	
+	v1 := router.Group("/api/v1")
+	{
+		v1.POST("/user-stories/:id/acceptance-criteria", handler.CreateAcceptanceCriteria)
+		v1.GET("/acceptance-criteria/:id", handler.GetAcceptanceCriteria)
+		v1.PUT("/acceptance-criteria/:id", handler.UpdateAcceptanceCriteria)
+		v1.DELETE("/acceptance-criteria/:id", handler.DeleteAcceptanceCriteria)
+		v1.GET("/acceptance-criteria", handler.ListAcceptanceCriteria)
+		v1.GET("/user-stories/:id/acceptance-criteria", handler.GetAcceptanceCriteriaByUserStory)
+	}
+	
+	return router, mockService
+}
+
+func TestAcceptanceCriteriaHandler_CreateAcceptanceCriteria(t *testing.T) {
+	router, mockService := setupAcceptanceCriteriaTestRouter()
+
+	userStoryID := uuid.New()
+	authorID := uuid.New()
+	acceptanceCriteriaID := uuid.New()
+
+	tests := []struct {
+		name           string
+		userStoryID    string
+		requestBody    interface{}
+		setupMocks     func()
+		expectedStatus int
+		checkResponse  func(*testing.T, *httptest.ResponseRecorder)
+	}{
+		{
+			name:        "successful creation",
+			userStoryID: userStoryID.String(),
+			requestBody: service.CreateAcceptanceCriteriaRequest{
+				AuthorID:    authorID,
+				Description: "WHEN user clicks submit THEN system SHALL validate the form",
+			},
+			setupMocks: func() {
+				expectedReq := service.CreateAcceptanceCriteriaRequest{
+					UserStoryID: userStoryID,
+					AuthorID:    authorID,
+					Description: "WHEN user clicks submit THEN system SHALL validate the form",
+				}
+				expectedResult := &models.AcceptanceCriteria{
+					ID:          acceptanceCriteriaID,
+					UserStoryID: userStoryID,
+					AuthorID:    authorID,
+					ReferenceID: "AC-001",
+					Description: "WHEN user clicks submit THEN system SHALL validate the form",
+				}
+				mockService.On("CreateAcceptanceCriteria", expectedReq).Return(expectedResult, nil)
+			},
+			expectedStatus: http.StatusCreated,
+			checkResponse: func(t *testing.T, w *httptest.ResponseRecorder) {
+				var response models.AcceptanceCriteria
+				err := json.Unmarshal(w.Body.Bytes(), &response)
+				assert.NoError(t, err)
+				assert.Equal(t, acceptanceCriteriaID, response.ID)
+				assert.Equal(t, "AC-001", response.ReferenceID)
+			},
+		},
+		{
+			name:        "invalid user story ID",
+			userStoryID: "invalid-uuid",
+			requestBody: service.CreateAcceptanceCriteriaRequest{
+				AuthorID:    authorID,
+				Description: "WHEN user clicks submit THEN system SHALL validate the form",
+			},
+			setupMocks:     func() {},
+			expectedStatus: http.StatusBadRequest,
+			checkResponse: func(t *testing.T, w *httptest.ResponseRecorder) {
+				var response map[string]interface{}
+				err := json.Unmarshal(w.Body.Bytes(), &response)
+				assert.NoError(t, err)
+				assert.Contains(t, response["error"], "Invalid user story ID format")
+			},
+		},
+		{
+			name:        "user story not found",
+			userStoryID: userStoryID.String(),
+			requestBody: service.CreateAcceptanceCriteriaRequest{
+				AuthorID:    authorID,
+				Description: "WHEN user clicks submit THEN system SHALL validate the form",
+			},
+			setupMocks: func() {
+				expectedReq := service.CreateAcceptanceCriteriaRequest{
+					UserStoryID: userStoryID,
+					AuthorID:    authorID,
+					Description: "WHEN user clicks submit THEN system SHALL validate the form",
+				}
+				mockService.On("CreateAcceptanceCriteria", expectedReq).Return(nil, service.ErrUserStoryNotFound)
+			},
+			expectedStatus: http.StatusBadRequest,
+			checkResponse: func(t *testing.T, w *httptest.ResponseRecorder) {
+				var response map[string]interface{}
+				err := json.Unmarshal(w.Body.Bytes(), &response)
+				assert.NoError(t, err)
+				assert.Contains(t, response["error"], "User story not found")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset mock
+			mockService.ExpectedCalls = nil
+			tt.setupMocks()
+
+			// Create request
+			body, _ := json.Marshal(tt.requestBody)
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/user-stories/"+tt.userStoryID+"/acceptance-criteria", bytes.NewBuffer(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+
+			// Execute request
+			router.ServeHTTP(w, req)
+
+			// Check response
+			assert.Equal(t, tt.expectedStatus, w.Code)
+			tt.checkResponse(t, w)
+
+			mockService.AssertExpectations(t)
+		})
+	}
+}
+
+func TestAcceptanceCriteriaHandler_GetAcceptanceCriteria(t *testing.T) {
+	router, mockService := setupAcceptanceCriteriaTestRouter()
+
+	acceptanceCriteriaID := uuid.New()
+	expectedAcceptanceCriteria := &models.AcceptanceCriteria{
+		ID:          acceptanceCriteriaID,
+		ReferenceID: "AC-001",
+		Description: "WHEN user clicks submit THEN system SHALL validate the form",
+	}
+
+	tests := []struct {
+		name           string
+		id             string
+		setupMocks     func()
+		expectedStatus int
+		checkResponse  func(*testing.T, *httptest.ResponseRecorder)
+	}{
+		{
+			name: "successful retrieval by UUID",
+			id:   acceptanceCriteriaID.String(),
+			setupMocks: func() {
+				mockService.On("GetAcceptanceCriteriaByID", acceptanceCriteriaID).Return(expectedAcceptanceCriteria, nil)
+			},
+			expectedStatus: http.StatusOK,
+			checkResponse: func(t *testing.T, w *httptest.ResponseRecorder) {
+				var response models.AcceptanceCriteria
+				err := json.Unmarshal(w.Body.Bytes(), &response)
+				assert.NoError(t, err)
+				assert.Equal(t, acceptanceCriteriaID, response.ID)
+			},
+		},
+		{
+			name: "successful retrieval by reference ID",
+			id:   "AC-001",
+			setupMocks: func() {
+				mockService.On("GetAcceptanceCriteriaByReferenceID", "AC-001").Return(expectedAcceptanceCriteria, nil)
+			},
+			expectedStatus: http.StatusOK,
+			checkResponse: func(t *testing.T, w *httptest.ResponseRecorder) {
+				var response models.AcceptanceCriteria
+				err := json.Unmarshal(w.Body.Bytes(), &response)
+				assert.NoError(t, err)
+				assert.Equal(t, "AC-001", response.ReferenceID)
+			},
+		},
+		{
+			name: "acceptance criteria not found",
+			id:   acceptanceCriteriaID.String(),
+			setupMocks: func() {
+				mockService.On("GetAcceptanceCriteriaByID", acceptanceCriteriaID).Return(nil, service.ErrAcceptanceCriteriaNotFound)
+			},
+			expectedStatus: http.StatusNotFound,
+			checkResponse: func(t *testing.T, w *httptest.ResponseRecorder) {
+				var response map[string]interface{}
+				err := json.Unmarshal(w.Body.Bytes(), &response)
+				assert.NoError(t, err)
+				assert.Contains(t, response["error"], "Acceptance criteria not found")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset mock
+			mockService.ExpectedCalls = nil
+			tt.setupMocks()
+
+			// Create request
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/acceptance-criteria/"+tt.id, nil)
+			w := httptest.NewRecorder()
+
+			// Execute request
+			router.ServeHTTP(w, req)
+
+			// Check response
+			assert.Equal(t, tt.expectedStatus, w.Code)
+			tt.checkResponse(t, w)
+
+			mockService.AssertExpectations(t)
+		})
+	}
+}
+
+func TestAcceptanceCriteriaHandler_DeleteAcceptanceCriteria(t *testing.T) {
+	router, mockService := setupAcceptanceCriteriaTestRouter()
+
+	acceptanceCriteriaID := uuid.New()
+
+	tests := []struct {
+		name           string
+		id             string
+		force          string
+		setupMocks     func()
+		expectedStatus int
+		checkResponse  func(*testing.T, *httptest.ResponseRecorder)
+	}{
+		{
+			name:  "successful deletion",
+			id:    acceptanceCriteriaID.String(),
+			force: "",
+			setupMocks: func() {
+				mockService.On("DeleteAcceptanceCriteria", acceptanceCriteriaID, false).Return(nil)
+			},
+			expectedStatus: http.StatusNoContent,
+			checkResponse: func(t *testing.T, w *httptest.ResponseRecorder) {
+				assert.Empty(t, w.Body.String())
+			},
+		},
+		{
+			name:  "force deletion",
+			id:    acceptanceCriteriaID.String(),
+			force: "true",
+			setupMocks: func() {
+				mockService.On("DeleteAcceptanceCriteria", acceptanceCriteriaID, true).Return(nil)
+			},
+			expectedStatus: http.StatusNoContent,
+			checkResponse: func(t *testing.T, w *httptest.ResponseRecorder) {
+				assert.Empty(t, w.Body.String())
+			},
+		},
+		{
+			name:  "acceptance criteria not found",
+			id:    acceptanceCriteriaID.String(),
+			force: "",
+			setupMocks: func() {
+				mockService.On("DeleteAcceptanceCriteria", acceptanceCriteriaID, false).Return(service.ErrAcceptanceCriteriaNotFound)
+			},
+			expectedStatus: http.StatusNotFound,
+			checkResponse: func(t *testing.T, w *httptest.ResponseRecorder) {
+				var response map[string]interface{}
+				err := json.Unmarshal(w.Body.Bytes(), &response)
+				assert.NoError(t, err)
+				assert.Contains(t, response["error"], "Acceptance criteria not found")
+			},
+		},
+		{
+			name:  "has requirements without force",
+			id:    acceptanceCriteriaID.String(),
+			force: "",
+			setupMocks: func() {
+				mockService.On("DeleteAcceptanceCriteria", acceptanceCriteriaID, false).Return(service.ErrAcceptanceCriteriaHasRequirements)
+			},
+			expectedStatus: http.StatusConflict,
+			checkResponse: func(t *testing.T, w *httptest.ResponseRecorder) {
+				var response map[string]interface{}
+				err := json.Unmarshal(w.Body.Bytes(), &response)
+				assert.NoError(t, err)
+				assert.Contains(t, response["error"], "has associated requirements")
+				assert.Contains(t, response["hint"], "force=true")
+			},
+		},
+		{
+			name:  "last acceptance criteria",
+			id:    acceptanceCriteriaID.String(),
+			force: "",
+			setupMocks: func() {
+				mockService.On("DeleteAcceptanceCriteria", acceptanceCriteriaID, false).Return(service.ErrUserStoryMustHaveAcceptanceCriteria)
+			},
+			expectedStatus: http.StatusConflict,
+			checkResponse: func(t *testing.T, w *httptest.ResponseRecorder) {
+				var response map[string]interface{}
+				err := json.Unmarshal(w.Body.Bytes(), &response)
+				assert.NoError(t, err)
+				assert.Contains(t, response["error"], "must have at least one acceptance criteria")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset mock
+			mockService.ExpectedCalls = nil
+			tt.setupMocks()
+
+			// Create request
+			url := "/api/v1/acceptance-criteria/" + tt.id
+			if tt.force != "" {
+				url += "?force=" + tt.force
+			}
+			req := httptest.NewRequest(http.MethodDelete, url, nil)
+			w := httptest.NewRecorder()
+
+			// Execute request
+			router.ServeHTTP(w, req)
+
+			// Check response
+			assert.Equal(t, tt.expectedStatus, w.Code)
+			tt.checkResponse(t, w)
+
+			mockService.AssertExpectations(t)
+		})
+	}
+}
+
+func TestAcceptanceCriteriaHandler_ListAcceptanceCriteria(t *testing.T) {
+	router, mockService := setupAcceptanceCriteriaTestRouter()
+
+	userStoryID := uuid.New()
+	authorID := uuid.New()
+	
+	expectedAcceptanceCriteria := []models.AcceptanceCriteria{
+		{
+			ID:          uuid.New(),
+			ReferenceID: "AC-001",
+			UserStoryID: userStoryID,
+			AuthorID:    authorID,
+			Description: "WHEN user clicks submit THEN system SHALL validate the form",
+		},
+		{
+			ID:          uuid.New(),
+			ReferenceID: "AC-002",
+			UserStoryID: userStoryID,
+			AuthorID:    authorID,
+			Description: "WHEN validation fails THEN system SHALL display error message",
+		},
+	}
+
+	tests := []struct {
+		name           string
+		queryParams    string
+		setupMocks     func()
+		expectedStatus int
+		checkResponse  func(*testing.T, *httptest.ResponseRecorder)
+	}{
+		{
+			name:        "successful list without filters",
+			queryParams: "",
+			setupMocks: func() {
+				expectedFilters := service.AcceptanceCriteriaFilters{}
+				mockService.On("ListAcceptanceCriteria", expectedFilters).Return(expectedAcceptanceCriteria, nil)
+			},
+			expectedStatus: http.StatusOK,
+			checkResponse: func(t *testing.T, w *httptest.ResponseRecorder) {
+				var response map[string]interface{}
+				err := json.Unmarshal(w.Body.Bytes(), &response)
+				assert.NoError(t, err)
+				assert.Equal(t, float64(2), response["count"])
+				
+				criteria := response["acceptance_criteria"].([]interface{})
+				assert.Len(t, criteria, 2)
+			},
+		},
+		{
+			name:        "successful list with user story filter",
+			queryParams: "?user_story_id=" + userStoryID.String(),
+			setupMocks: func() {
+				expectedFilters := service.AcceptanceCriteriaFilters{
+					UserStoryID: &userStoryID,
+				}
+				mockService.On("ListAcceptanceCriteria", expectedFilters).Return(expectedAcceptanceCriteria, nil)
+			},
+			expectedStatus: http.StatusOK,
+			checkResponse: func(t *testing.T, w *httptest.ResponseRecorder) {
+				var response map[string]interface{}
+				err := json.Unmarshal(w.Body.Bytes(), &response)
+				assert.NoError(t, err)
+				assert.Equal(t, float64(2), response["count"])
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset mock
+			mockService.ExpectedCalls = nil
+			tt.setupMocks()
+
+			// Create request
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/acceptance-criteria"+tt.queryParams, nil)
+			w := httptest.NewRecorder()
+
+			// Execute request
+			router.ServeHTTP(w, req)
+
+			// Check response
+			assert.Equal(t, tt.expectedStatus, w.Code)
+			tt.checkResponse(t, w)
+
+			mockService.AssertExpectations(t)
+		})
+	}
+}

--- a/internal/integration/acceptance_criteria_integration_test.go
+++ b/internal/integration/acceptance_criteria_integration_test.go
@@ -1,0 +1,464 @@
+package integration
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"product-requirements-management/internal/handlers"
+	"product-requirements-management/internal/models"
+	"product-requirements-management/internal/repository"
+	"product-requirements-management/internal/service"
+)
+
+// setupAcceptanceCriteriaTestServer creates a test server with in-memory database
+func setupAcceptanceCriteriaTestServer(t *testing.T) (*gin.Engine, *gorm.DB, func()) {
+	// Create in-memory SQLite database
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+
+	// Auto-migrate models
+	err = models.AutoMigrate(db)
+	require.NoError(t, err)
+
+	// Seed default data
+	err = models.SeedDefaultData(db)
+	require.NoError(t, err)
+
+	// Create repositories
+	epicRepo := repository.NewEpicRepository(db)
+	userRepo := repository.NewUserRepository(db)
+	userStoryRepo := repository.NewUserStoryRepository(db)
+	acceptanceCriteriaRepo := repository.NewAcceptanceCriteriaRepository(db)
+
+	// Create services
+	epicService := service.NewEpicService(epicRepo, userRepo)
+	userStoryService := service.NewUserStoryService(userStoryRepo, epicRepo, userRepo)
+	acceptanceCriteriaService := service.NewAcceptanceCriteriaService(acceptanceCriteriaRepo, userStoryRepo, userRepo)
+
+	// Create handlers
+	epicHandler := handlers.NewEpicHandler(epicService)
+	userStoryHandler := handlers.NewUserStoryHandler(userStoryService)
+	acceptanceCriteriaHandler := handlers.NewAcceptanceCriteriaHandler(acceptanceCriteriaService)
+
+	// Setup Gin router
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+
+	v1 := router.Group("/api/v1")
+	{
+		// Epic routes
+		epics := v1.Group("/epics")
+		{
+			epics.POST("", epicHandler.CreateEpic)
+			epics.GET("/:id", epicHandler.GetEpic)
+			epics.POST("/:id/user-stories", userStoryHandler.CreateUserStoryInEpic)
+		}
+
+		// User Story routes
+		userStories := v1.Group("/user-stories")
+		{
+			userStories.POST("", userStoryHandler.CreateUserStory)
+			userStories.GET("/:id", userStoryHandler.GetUserStory)
+			userStories.POST("/:id/acceptance-criteria", acceptanceCriteriaHandler.CreateAcceptanceCriteria)
+			userStories.GET("/:id/acceptance-criteria", acceptanceCriteriaHandler.GetAcceptanceCriteriaByUserStory)
+		}
+
+		// Acceptance Criteria routes
+		acceptanceCriteria := v1.Group("/acceptance-criteria")
+		{
+			acceptanceCriteria.GET("", acceptanceCriteriaHandler.ListAcceptanceCriteria)
+			acceptanceCriteria.GET("/:id", acceptanceCriteriaHandler.GetAcceptanceCriteria)
+			acceptanceCriteria.PUT("/:id", acceptanceCriteriaHandler.UpdateAcceptanceCriteria)
+			acceptanceCriteria.DELETE("/:id", acceptanceCriteriaHandler.DeleteAcceptanceCriteria)
+		}
+	}
+
+	cleanup := func() {
+		sqlDB, _ := db.DB()
+		sqlDB.Close()
+	}
+
+	return router, db, cleanup
+}
+
+// createAcceptanceCriteriaTestUser creates a test user in the database
+func createAcceptanceCriteriaTestUser(t *testing.T, db *gorm.DB) *models.User {
+	user := &models.User{
+		ID:           uuid.New(),
+		Username:     "testuser",
+		Email:        "test@example.com",
+		PasswordHash: "hashedpassword",
+		Role:         models.RoleUser,
+	}
+
+	err := db.Create(user).Error
+	require.NoError(t, err)
+
+	return user
+}
+
+// createAcceptanceCriteriaTestEpic creates a test epic in the database
+func createAcceptanceCriteriaTestEpic(t *testing.T, db *gorm.DB, creatorID uuid.UUID) *models.Epic {
+	epic := &models.Epic{
+		ID:          uuid.New(),
+		CreatorID:   creatorID,
+		AssigneeID:  creatorID,
+		Priority:    models.PriorityHigh,
+		Status:      models.EpicStatusBacklog,
+		Title:       "Test Epic",
+		Description: stringPtr("Epic description"),
+	}
+
+	err := db.Create(epic).Error
+	require.NoError(t, err)
+
+	return epic
+}
+
+// createAcceptanceCriteriaTestUserStory creates a test user story in the database
+func createAcceptanceCriteriaTestUserStory(t *testing.T, db *gorm.DB, epicID, creatorID uuid.UUID) *models.UserStory {
+	description := "As a user, I want to test, so that I can verify"
+	userStory := &models.UserStory{
+		ID:          uuid.New(),
+		EpicID:      epicID,
+		CreatorID:   creatorID,
+		AssigneeID:  creatorID,
+		Priority:    models.PriorityHigh,
+		Status:      models.UserStoryStatusBacklog,
+		Title:       "Test User Story",
+		Description: &description,
+	}
+
+	err := db.Create(userStory).Error
+	require.NoError(t, err)
+
+	return userStory
+}
+
+
+
+func TestAcceptanceCriteriaIntegration(t *testing.T) {
+	// Setup test environment
+	router, db, cleanup := setupAcceptanceCriteriaTestServer(t)
+	defer cleanup()
+
+	// Create test user
+	user := createAcceptanceCriteriaTestUser(t, db)
+
+	// Create test epic
+	epic := createAcceptanceCriteriaTestEpic(t, db, user.ID)
+
+	// Create test user story
+	userStory := createAcceptanceCriteriaTestUserStory(t, db, epic.ID, user.ID)
+
+	t.Run("Create Acceptance Criteria", func(t *testing.T) {
+		requestBody := map[string]interface{}{
+			"author_id":   user.ID.String(),
+			"description": "WHEN user clicks submit THEN system SHALL validate the form",
+		}
+
+		body, _ := json.Marshal(requestBody)
+		req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/user-stories/%s/acceptance-criteria", userStory.ID.String()), bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusCreated, w.Code)
+
+		var response models.AcceptanceCriteria
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		assert.NotEqual(t, uuid.Nil, response.ID)
+		assert.NotEmpty(t, response.ReferenceID)
+		assert.Equal(t, userStory.ID, response.UserStoryID)
+		assert.Equal(t, user.ID, response.AuthorID)
+		assert.Equal(t, "WHEN user clicks submit THEN system SHALL validate the form", response.Description)
+		assert.False(t, response.CreatedAt.IsZero())
+		assert.False(t, response.LastModified.IsZero())
+	})
+
+	// Create acceptance criteria for further tests
+	acceptanceCriteria := createTestAcceptanceCriteria(t, db, userStory.ID, user.ID, "WHEN user clicks submit THEN system SHALL validate the form")
+
+	t.Run("Get Acceptance Criteria by ID", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/acceptance-criteria/%s", acceptanceCriteria.ID.String()), nil)
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response models.AcceptanceCriteria
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		assert.Equal(t, acceptanceCriteria.ID, response.ID)
+		assert.Equal(t, acceptanceCriteria.ReferenceID, response.ReferenceID)
+		assert.Equal(t, acceptanceCriteria.Description, response.Description)
+	})
+
+	t.Run("Get Acceptance Criteria by Reference ID", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/acceptance-criteria/%s", acceptanceCriteria.ReferenceID), nil)
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response models.AcceptanceCriteria
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		assert.Equal(t, acceptanceCriteria.ID, response.ID)
+		assert.Equal(t, acceptanceCriteria.ReferenceID, response.ReferenceID)
+	})
+
+	t.Run("Update Acceptance Criteria", func(t *testing.T) {
+		requestBody := map[string]interface{}{
+			"description": "WHEN user submits form THEN system SHALL validate all required fields",
+		}
+
+		body, _ := json.Marshal(requestBody)
+		req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/v1/acceptance-criteria/%s", acceptanceCriteria.ID.String()), bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response models.AcceptanceCriteria
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		assert.Equal(t, acceptanceCriteria.ID, response.ID)
+		assert.Equal(t, "WHEN user submits form THEN system SHALL validate all required fields", response.Description)
+		assert.True(t, response.LastModified.After(response.CreatedAt))
+	})
+
+	t.Run("List Acceptance Criteria", func(t *testing.T) {
+		// Create another acceptance criteria for the same user story
+		createTestAcceptanceCriteria(t, db, userStory.ID, user.ID, "WHEN validation fails THEN system SHALL display error message")
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/acceptance-criteria", nil)
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		assert.Equal(t, float64(2), response["count"])
+		
+		criteria := response["acceptance_criteria"].([]interface{})
+		assert.Len(t, criteria, 2)
+	})
+
+	t.Run("List Acceptance Criteria with User Story Filter", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/acceptance-criteria?user_story_id=%s", userStory.ID.String()), nil)
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		assert.Equal(t, float64(2), response["count"])
+		
+		criteria := response["acceptance_criteria"].([]interface{})
+		assert.Len(t, criteria, 2)
+	})
+
+	t.Run("Get Acceptance Criteria by User Story", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/user-stories/%s/acceptance-criteria", userStory.ID.String()), nil)
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+
+		assert.Equal(t, float64(2), response["count"])
+		
+		criteria := response["acceptance_criteria"].([]interface{})
+		assert.Len(t, criteria, 2)
+	})
+
+	t.Run("Delete Acceptance Criteria - Prevent Last One", func(t *testing.T) {
+		// First, delete one acceptance criteria to leave only one
+		var allCriteria []models.AcceptanceCriteria
+		err := db.Where("user_story_id = ?", userStory.ID).Find(&allCriteria).Error
+		require.NoError(t, err)
+		require.Len(t, allCriteria, 2)
+
+		// Delete the first one
+		req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/acceptance-criteria/%s", allCriteria[0].ID.String()), nil)
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusNoContent, w.Code)
+
+		// Now try to delete the last one - should fail
+		req = httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/acceptance-criteria/%s", allCriteria[1].ID.String()), nil)
+		w = httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusConflict, w.Code)
+
+		var response map[string]interface{}
+		err = json.Unmarshal(w.Body.Bytes(), &response)
+		require.NoError(t, err)
+		assert.Contains(t, response["error"], "must have at least one acceptance criteria")
+	})
+
+	t.Run("Force Delete Last Acceptance Criteria", func(t *testing.T) {
+		// Get the remaining acceptance criteria
+		var remainingCriteria models.AcceptanceCriteria
+		err := db.Where("user_story_id = ?", userStory.ID).First(&remainingCriteria).Error
+		require.NoError(t, err)
+
+		// Force delete the last one
+		req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/acceptance-criteria/%s?force=true", remainingCriteria.ID.String()), nil)
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusNoContent, w.Code)
+
+		// Verify it's deleted
+		var count int64
+		err = db.Model(&models.AcceptanceCriteria{}).Where("user_story_id = ?", userStory.ID).Count(&count).Error
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), count)
+	})
+
+	t.Run("Error Cases", func(t *testing.T) {
+		t.Run("Create with Invalid User Story ID", func(t *testing.T) {
+			requestBody := map[string]interface{}{
+				"author_id":   user.ID.String(),
+				"description": "WHEN user clicks submit THEN system SHALL validate the form",
+			}
+
+			body, _ := json.Marshal(requestBody)
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/user-stories/invalid-uuid/acceptance-criteria", bytes.NewBuffer(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+		})
+
+		t.Run("Create with Non-existent User Story", func(t *testing.T) {
+			nonExistentID := uuid.New()
+			requestBody := map[string]interface{}{
+				"author_id":   user.ID.String(),
+				"description": "WHEN user clicks submit THEN system SHALL validate the form",
+			}
+
+			body, _ := json.Marshal(requestBody)
+			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/api/v1/user-stories/%s/acceptance-criteria", nonExistentID.String()), bytes.NewBuffer(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+
+			var response map[string]interface{}
+			err := json.Unmarshal(w.Body.Bytes(), &response)
+			require.NoError(t, err)
+			assert.Contains(t, response["error"], "User story not found")
+		})
+
+		t.Run("Get Non-existent Acceptance Criteria", func(t *testing.T) {
+			nonExistentID := uuid.New()
+			req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/acceptance-criteria/%s", nonExistentID.String()), nil)
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusNotFound, w.Code)
+
+			var response map[string]interface{}
+			err := json.Unmarshal(w.Body.Bytes(), &response)
+			require.NoError(t, err)
+			assert.Contains(t, response["error"], "Acceptance criteria not found")
+		})
+
+		t.Run("Update Non-existent Acceptance Criteria", func(t *testing.T) {
+			nonExistentID := uuid.New()
+			requestBody := map[string]interface{}{
+				"description": "Updated description",
+			}
+
+			body, _ := json.Marshal(requestBody)
+			req := httptest.NewRequest(http.MethodPut, fmt.Sprintf("/api/v1/acceptance-criteria/%s", nonExistentID.String()), bytes.NewBuffer(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusNotFound, w.Code)
+
+			var response map[string]interface{}
+			err := json.Unmarshal(w.Body.Bytes(), &response)
+			require.NoError(t, err)
+			assert.Contains(t, response["error"], "Acceptance criteria not found")
+		})
+
+		t.Run("Delete Non-existent Acceptance Criteria", func(t *testing.T) {
+			nonExistentID := uuid.New()
+			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/api/v1/acceptance-criteria/%s", nonExistentID.String()), nil)
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusNotFound, w.Code)
+
+			var response map[string]interface{}
+			err := json.Unmarshal(w.Body.Bytes(), &response)
+			require.NoError(t, err)
+			assert.Contains(t, response["error"], "Acceptance criteria not found")
+		})
+	})
+}
+
+// Helper function to create test acceptance criteria
+func createTestAcceptanceCriteria(t *testing.T, db *gorm.DB, userStoryID, authorID uuid.UUID, description string) *models.AcceptanceCriteria {
+	acceptanceCriteria := &models.AcceptanceCriteria{
+		ID:          uuid.New(),
+		UserStoryID: userStoryID,
+		AuthorID:    authorID,
+		Description: description,
+	}
+
+	err := db.Create(acceptanceCriteria).Error
+	require.NoError(t, err)
+
+	return acceptanceCriteria
+}

--- a/internal/models/acceptance_criteria.go
+++ b/internal/models/acceptance_criteria.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -30,9 +31,14 @@ func (ac *AcceptanceCriteria) BeforeCreate(tx *gorm.DB) error {
 		ac.ID = uuid.New()
 	}
 	if ac.ReferenceID == "" {
-		// Generate reference ID - in production this would use database sequences
-		ac.ReferenceID = "AC-001" // Simplified for testing
+		// Generate reference ID using a simple counter
+		var count int64
+		tx.Model(&AcceptanceCriteria{}).Count(&count)
+		ac.ReferenceID = fmt.Sprintf("AC-%03d", count+1)
 	}
+	now := time.Now().UTC()
+	ac.CreatedAt = now
+	ac.LastModified = now
 	return nil
 }
 
@@ -76,3 +82,4 @@ func (ac *AcceptanceCriteria) IsEARSFormat() bool {
 func (ac *AcceptanceCriteria) GetFormattedDescription() string {
 	return ac.Description
 }
+

--- a/internal/models/user_story.go
+++ b/internal/models/user_story.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -135,14 +136,5 @@ func (us *UserStory) IsUserStoryTemplate() bool {
 
 // Helper function to check if string contains substring
 func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > len(substr) && (s[:len(substr)] == substr || s[len(s)-len(substr):] == substr || containsAt(s, substr)))
-}
-
-func containsAt(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
+	return strings.Contains(s, substr)
 }

--- a/internal/service/acceptance_criteria_service.go
+++ b/internal/service/acceptance_criteria_service.go
@@ -1,0 +1,268 @@
+package service
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"product-requirements-management/internal/models"
+	"product-requirements-management/internal/repository"
+)
+
+var (
+	ErrAcceptanceCriteriaNotFound      = errors.New("acceptance criteria not found")
+	ErrAcceptanceCriteriaHasRequirements = errors.New("acceptance criteria has associated requirements and cannot be deleted")
+	ErrUserStoryMustHaveAcceptanceCriteria = errors.New("user story must have at least one acceptance criteria")
+)
+
+// AcceptanceCriteriaService defines the interface for acceptance criteria business logic
+type AcceptanceCriteriaService interface {
+	CreateAcceptanceCriteria(req CreateAcceptanceCriteriaRequest) (*models.AcceptanceCriteria, error)
+	GetAcceptanceCriteriaByID(id uuid.UUID) (*models.AcceptanceCriteria, error)
+	GetAcceptanceCriteriaByReferenceID(referenceID string) (*models.AcceptanceCriteria, error)
+	UpdateAcceptanceCriteria(id uuid.UUID, req UpdateAcceptanceCriteriaRequest) (*models.AcceptanceCriteria, error)
+	DeleteAcceptanceCriteria(id uuid.UUID, force bool) error
+	ListAcceptanceCriteria(filters AcceptanceCriteriaFilters) ([]models.AcceptanceCriteria, error)
+	GetAcceptanceCriteriaByUserStory(userStoryID uuid.UUID) ([]models.AcceptanceCriteria, error)
+	GetAcceptanceCriteriaByAuthor(authorID uuid.UUID) ([]models.AcceptanceCriteria, error)
+	ValidateUserStoryHasAcceptanceCriteria(userStoryID uuid.UUID) error
+}
+
+// CreateAcceptanceCriteriaRequest represents the request to create acceptance criteria
+type CreateAcceptanceCriteriaRequest struct {
+	UserStoryID uuid.UUID `json:"user_story_id,omitempty"`
+	AuthorID    uuid.UUID `json:"author_id" binding:"required"`
+	Description string    `json:"description" binding:"required"`
+}
+
+// UpdateAcceptanceCriteriaRequest represents the request to update acceptance criteria
+type UpdateAcceptanceCriteriaRequest struct {
+	Description *string `json:"description,omitempty"`
+}
+
+// AcceptanceCriteriaFilters represents filters for listing acceptance criteria
+type AcceptanceCriteriaFilters struct {
+	UserStoryID *uuid.UUID `json:"user_story_id,omitempty"`
+	AuthorID    *uuid.UUID `json:"author_id,omitempty"`
+	OrderBy     string     `json:"order_by,omitempty"`
+	Limit       int        `json:"limit,omitempty"`
+	Offset      int        `json:"offset,omitempty"`
+}
+
+// acceptanceCriteriaService implements AcceptanceCriteriaService interface
+type acceptanceCriteriaService struct {
+	acceptanceCriteriaRepo repository.AcceptanceCriteriaRepository
+	userStoryRepo          repository.UserStoryRepository
+	userRepo               repository.UserRepository
+}
+
+// NewAcceptanceCriteriaService creates a new acceptance criteria service instance
+func NewAcceptanceCriteriaService(
+	acceptanceCriteriaRepo repository.AcceptanceCriteriaRepository,
+	userStoryRepo repository.UserStoryRepository,
+	userRepo repository.UserRepository,
+) AcceptanceCriteriaService {
+	return &acceptanceCriteriaService{
+		acceptanceCriteriaRepo: acceptanceCriteriaRepo,
+		userStoryRepo:          userStoryRepo,
+		userRepo:               userRepo,
+	}
+}
+
+// CreateAcceptanceCriteria creates new acceptance criteria
+func (s *acceptanceCriteriaService) CreateAcceptanceCriteria(req CreateAcceptanceCriteriaRequest) (*models.AcceptanceCriteria, error) {
+	// Validate user story exists
+	if exists, err := s.userStoryRepo.Exists(req.UserStoryID); err != nil {
+		return nil, fmt.Errorf("failed to check user story existence: %w", err)
+	} else if !exists {
+		return nil, ErrUserStoryNotFound
+	}
+
+	// Validate author exists
+	if exists, err := s.userRepo.Exists(req.AuthorID); err != nil {
+		return nil, fmt.Errorf("failed to check author existence: %w", err)
+	} else if !exists {
+		return nil, ErrUserNotFound
+	}
+
+	acceptanceCriteria := &models.AcceptanceCriteria{
+		ID:          uuid.New(),
+		UserStoryID: req.UserStoryID,
+		AuthorID:    req.AuthorID,
+		Description: req.Description,
+	}
+
+	if err := s.acceptanceCriteriaRepo.Create(acceptanceCriteria); err != nil {
+		return nil, fmt.Errorf("failed to create acceptance criteria: %w", err)
+	}
+
+	return acceptanceCriteria, nil
+}
+
+// GetAcceptanceCriteriaByID retrieves acceptance criteria by its ID
+func (s *acceptanceCriteriaService) GetAcceptanceCriteriaByID(id uuid.UUID) (*models.AcceptanceCriteria, error) {
+	acceptanceCriteria, err := s.acceptanceCriteriaRepo.GetByID(id)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrAcceptanceCriteriaNotFound
+		}
+		return nil, fmt.Errorf("failed to get acceptance criteria: %w", err)
+	}
+	return acceptanceCriteria, nil
+}
+
+// GetAcceptanceCriteriaByReferenceID retrieves acceptance criteria by its reference ID
+func (s *acceptanceCriteriaService) GetAcceptanceCriteriaByReferenceID(referenceID string) (*models.AcceptanceCriteria, error) {
+	acceptanceCriteria, err := s.acceptanceCriteriaRepo.GetByReferenceID(referenceID)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrAcceptanceCriteriaNotFound
+		}
+		return nil, fmt.Errorf("failed to get acceptance criteria: %w", err)
+	}
+	return acceptanceCriteria, nil
+}
+
+// UpdateAcceptanceCriteria updates existing acceptance criteria
+func (s *acceptanceCriteriaService) UpdateAcceptanceCriteria(id uuid.UUID, req UpdateAcceptanceCriteriaRequest) (*models.AcceptanceCriteria, error) {
+	acceptanceCriteria, err := s.acceptanceCriteriaRepo.GetByID(id)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return nil, ErrAcceptanceCriteriaNotFound
+		}
+		return nil, fmt.Errorf("failed to get acceptance criteria: %w", err)
+	}
+
+	// Update fields if provided
+	if req.Description != nil {
+		acceptanceCriteria.Description = *req.Description
+	}
+
+	if err := s.acceptanceCriteriaRepo.Update(acceptanceCriteria); err != nil {
+		return nil, fmt.Errorf("failed to update acceptance criteria: %w", err)
+	}
+
+	return acceptanceCriteria, nil
+}
+
+// DeleteAcceptanceCriteria deletes acceptance criteria with dependency validation
+func (s *acceptanceCriteriaService) DeleteAcceptanceCriteria(id uuid.UUID, force bool) error {
+	// Check if acceptance criteria exists
+	acceptanceCriteria, err := s.acceptanceCriteriaRepo.GetByID(id)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			return ErrAcceptanceCriteriaNotFound
+		}
+		return fmt.Errorf("failed to get acceptance criteria: %w", err)
+	}
+
+	// Check for requirements unless force delete
+	if !force {
+		hasRequirements, err := s.acceptanceCriteriaRepo.HasRequirements(id)
+		if err != nil {
+			return fmt.Errorf("failed to check requirements: %w", err)
+		}
+		if hasRequirements {
+			return ErrAcceptanceCriteriaHasRequirements
+		}
+	}
+
+	// Check if this is the last acceptance criteria for the user story
+	if !force {
+		count, err := s.acceptanceCriteriaRepo.CountByUserStory(acceptanceCriteria.UserStoryID)
+		if err != nil {
+			return fmt.Errorf("failed to count acceptance criteria: %w", err)
+		}
+		if count <= 1 {
+			return ErrUserStoryMustHaveAcceptanceCriteria
+		}
+	}
+
+	// Delete the acceptance criteria (cascade will handle requirements if force=true)
+	if err := s.acceptanceCriteriaRepo.Delete(id); err != nil {
+		return fmt.Errorf("failed to delete acceptance criteria: %w", err)
+	}
+
+	return nil
+}
+
+// ListAcceptanceCriteria retrieves acceptance criteria with optional filtering
+func (s *acceptanceCriteriaService) ListAcceptanceCriteria(filters AcceptanceCriteriaFilters) ([]models.AcceptanceCriteria, error) {
+	// Build filter map
+	filterMap := make(map[string]interface{})
+	
+	if filters.UserStoryID != nil {
+		filterMap["user_story_id"] = *filters.UserStoryID
+	}
+	if filters.AuthorID != nil {
+		filterMap["author_id"] = *filters.AuthorID
+	}
+
+	// Set default ordering
+	orderBy := "created_at DESC"
+	if filters.OrderBy != "" {
+		orderBy = filters.OrderBy
+	}
+
+	// Set default limit
+	limit := 50
+	if filters.Limit > 0 {
+		limit = filters.Limit
+	}
+
+	acceptanceCriteria, err := s.acceptanceCriteriaRepo.List(filterMap, orderBy, limit, filters.Offset)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list acceptance criteria: %w", err)
+	}
+
+	return acceptanceCriteria, nil
+}
+
+// GetAcceptanceCriteriaByUserStory retrieves acceptance criteria by user story ID
+func (s *acceptanceCriteriaService) GetAcceptanceCriteriaByUserStory(userStoryID uuid.UUID) ([]models.AcceptanceCriteria, error) {
+	// Validate user story exists
+	if exists, err := s.userStoryRepo.Exists(userStoryID); err != nil {
+		return nil, fmt.Errorf("failed to check user story existence: %w", err)
+	} else if !exists {
+		return nil, ErrUserStoryNotFound
+	}
+
+	acceptanceCriteria, err := s.acceptanceCriteriaRepo.GetByUserStory(userStoryID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get acceptance criteria by user story: %w", err)
+	}
+
+	return acceptanceCriteria, nil
+}
+
+// GetAcceptanceCriteriaByAuthor retrieves acceptance criteria by author ID
+func (s *acceptanceCriteriaService) GetAcceptanceCriteriaByAuthor(authorID uuid.UUID) ([]models.AcceptanceCriteria, error) {
+	// Validate author exists
+	if exists, err := s.userRepo.Exists(authorID); err != nil {
+		return nil, fmt.Errorf("failed to check author existence: %w", err)
+	} else if !exists {
+		return nil, ErrUserNotFound
+	}
+
+	acceptanceCriteria, err := s.acceptanceCriteriaRepo.GetByAuthor(authorID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get acceptance criteria by author: %w", err)
+	}
+
+	return acceptanceCriteria, nil
+}
+
+// ValidateUserStoryHasAcceptanceCriteria validates that a user story has at least one acceptance criteria
+func (s *acceptanceCriteriaService) ValidateUserStoryHasAcceptanceCriteria(userStoryID uuid.UUID) error {
+	count, err := s.acceptanceCriteriaRepo.CountByUserStory(userStoryID)
+	if err != nil {
+		return fmt.Errorf("failed to count acceptance criteria: %w", err)
+	}
+	
+	if count == 0 {
+		return ErrUserStoryMustHaveAcceptanceCriteria
+	}
+	
+	return nil
+}

--- a/internal/service/acceptance_criteria_service_test.go
+++ b/internal/service/acceptance_criteria_service_test.go
@@ -1,0 +1,413 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"gorm.io/gorm"
+
+	"product-requirements-management/internal/models"
+	"product-requirements-management/internal/repository"
+)
+
+// MockAcceptanceCriteriaRepository is a mock implementation of AcceptanceCriteriaRepository
+type MockAcceptanceCriteriaRepository struct {
+	mock.Mock
+}
+
+func (m *MockAcceptanceCriteriaRepository) Create(entity *models.AcceptanceCriteria) error {
+	args := m.Called(entity)
+	return args.Error(0)
+}
+
+func (m *MockAcceptanceCriteriaRepository) GetByID(id uuid.UUID) (*models.AcceptanceCriteria, error) {
+	args := m.Called(id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.AcceptanceCriteria), args.Error(1)
+}
+
+func (m *MockAcceptanceCriteriaRepository) GetByReferenceID(referenceID string) (*models.AcceptanceCriteria, error) {
+	args := m.Called(referenceID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.AcceptanceCriteria), args.Error(1)
+}
+
+func (m *MockAcceptanceCriteriaRepository) Update(entity *models.AcceptanceCriteria) error {
+	args := m.Called(entity)
+	return args.Error(0)
+}
+
+func (m *MockAcceptanceCriteriaRepository) Delete(id uuid.UUID) error {
+	args := m.Called(id)
+	return args.Error(0)
+}
+
+func (m *MockAcceptanceCriteriaRepository) List(filters map[string]interface{}, orderBy string, limit, offset int) ([]models.AcceptanceCriteria, error) {
+	args := m.Called(filters, orderBy, limit, offset)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]models.AcceptanceCriteria), args.Error(1)
+}
+
+func (m *MockAcceptanceCriteriaRepository) Count(filters map[string]interface{}) (int64, error) {
+	args := m.Called(filters)
+	return args.Get(0).(int64), args.Error(1)
+}
+
+func (m *MockAcceptanceCriteriaRepository) Exists(id uuid.UUID) (bool, error) {
+	args := m.Called(id)
+	return args.Get(0).(bool), args.Error(1)
+}
+
+func (m *MockAcceptanceCriteriaRepository) ExistsByReferenceID(referenceID string) (bool, error) {
+	args := m.Called(referenceID)
+	return args.Get(0).(bool), args.Error(1)
+}
+
+func (m *MockAcceptanceCriteriaRepository) WithTransaction(fn func(*gorm.DB) error) error {
+	args := m.Called(fn)
+	return args.Error(0)
+}
+
+func (m *MockAcceptanceCriteriaRepository) GetDB() *gorm.DB {
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil
+	}
+	return args.Get(0).(*gorm.DB)
+}
+
+func (m *MockAcceptanceCriteriaRepository) GetByUserStory(userStoryID uuid.UUID) ([]models.AcceptanceCriteria, error) {
+	args := m.Called(userStoryID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]models.AcceptanceCriteria), args.Error(1)
+}
+
+func (m *MockAcceptanceCriteriaRepository) GetByAuthor(authorID uuid.UUID) ([]models.AcceptanceCriteria, error) {
+	args := m.Called(authorID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]models.AcceptanceCriteria), args.Error(1)
+}
+
+func (m *MockAcceptanceCriteriaRepository) HasRequirements(id uuid.UUID) (bool, error) {
+	args := m.Called(id)
+	return args.Get(0).(bool), args.Error(1)
+}
+
+func (m *MockAcceptanceCriteriaRepository) CountByUserStory(userStoryID uuid.UUID) (int64, error) {
+	args := m.Called(userStoryID)
+	return args.Get(0).(int64), args.Error(1)
+}
+
+func TestAcceptanceCriteriaService_CreateAcceptanceCriteria(t *testing.T) {
+	mockAcceptanceCriteriaRepo := new(MockAcceptanceCriteriaRepository)
+	mockUserStoryRepo := new(MockUserStoryRepository)
+	mockUserRepo := new(MockUserRepository)
+
+	service := NewAcceptanceCriteriaService(mockAcceptanceCriteriaRepo, mockUserStoryRepo, mockUserRepo)
+
+	userStoryID := uuid.New()
+	authorID := uuid.New()
+
+	tests := []struct {
+		name          string
+		request       CreateAcceptanceCriteriaRequest
+		setupMocks    func()
+		expectedError error
+	}{
+		{
+			name: "successful creation",
+			request: CreateAcceptanceCriteriaRequest{
+				UserStoryID: userStoryID,
+				AuthorID:    authorID,
+				Description: "WHEN user clicks submit THEN system SHALL validate the form",
+			},
+			setupMocks: func() {
+				mockUserStoryRepo.On("Exists", userStoryID).Return(true, nil)
+				mockUserRepo.On("Exists", authorID).Return(true, nil)
+				mockAcceptanceCriteriaRepo.On("Create", mock.AnythingOfType("*models.AcceptanceCriteria")).Return(nil)
+			},
+			expectedError: nil,
+		},
+		{
+			name: "user story not found",
+			request: CreateAcceptanceCriteriaRequest{
+				UserStoryID: userStoryID,
+				AuthorID:    authorID,
+				Description: "WHEN user clicks submit THEN system SHALL validate the form",
+			},
+			setupMocks: func() {
+				mockUserStoryRepo.On("Exists", userStoryID).Return(false, nil)
+			},
+			expectedError: ErrUserStoryNotFound,
+		},
+		{
+			name: "author not found",
+			request: CreateAcceptanceCriteriaRequest{
+				UserStoryID: userStoryID,
+				AuthorID:    authorID,
+				Description: "WHEN user clicks submit THEN system SHALL validate the form",
+			},
+			setupMocks: func() {
+				mockUserStoryRepo.On("Exists", userStoryID).Return(true, nil)
+				mockUserRepo.On("Exists", authorID).Return(false, nil)
+			},
+			expectedError: ErrUserNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset mocks
+			mockAcceptanceCriteriaRepo.ExpectedCalls = nil
+			mockUserStoryRepo.ExpectedCalls = nil
+			mockUserRepo.ExpectedCalls = nil
+
+			tt.setupMocks()
+
+			result, err := service.CreateAcceptanceCriteria(tt.request)
+
+			if tt.expectedError != nil {
+				assert.Error(t, err)
+				assert.True(t, errors.Is(err, tt.expectedError) || err.Error() == tt.expectedError.Error())
+				assert.Nil(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+				assert.Equal(t, tt.request.UserStoryID, result.UserStoryID)
+				assert.Equal(t, tt.request.AuthorID, result.AuthorID)
+				assert.Equal(t, tt.request.Description, result.Description)
+			}
+
+			mockAcceptanceCriteriaRepo.AssertExpectations(t)
+			mockUserStoryRepo.AssertExpectations(t)
+			mockUserRepo.AssertExpectations(t)
+		})
+	}
+}
+
+func TestAcceptanceCriteriaService_GetAcceptanceCriteriaByID(t *testing.T) {
+	mockAcceptanceCriteriaRepo := new(MockAcceptanceCriteriaRepository)
+	mockUserStoryRepo := new(MockUserStoryRepository)
+	mockUserRepo := new(MockUserRepository)
+
+	service := NewAcceptanceCriteriaService(mockAcceptanceCriteriaRepo, mockUserStoryRepo, mockUserRepo)
+
+	acceptanceCriteriaID := uuid.New()
+	expectedAcceptanceCriteria := &models.AcceptanceCriteria{
+		ID:          acceptanceCriteriaID,
+		ReferenceID: "AC-001",
+		Description: "WHEN user clicks submit THEN system SHALL validate the form",
+	}
+
+	tests := []struct {
+		name          string
+		id            uuid.UUID
+		setupMocks    func()
+		expectedError error
+	}{
+		{
+			name: "successful retrieval",
+			id:   acceptanceCriteriaID,
+			setupMocks: func() {
+				mockAcceptanceCriteriaRepo.On("GetByID", acceptanceCriteriaID).Return(expectedAcceptanceCriteria, nil)
+			},
+			expectedError: nil,
+		},
+		{
+			name: "acceptance criteria not found",
+			id:   acceptanceCriteriaID,
+			setupMocks: func() {
+				mockAcceptanceCriteriaRepo.On("GetByID", acceptanceCriteriaID).Return(nil, repository.ErrNotFound)
+			},
+			expectedError: ErrAcceptanceCriteriaNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset mocks
+			mockAcceptanceCriteriaRepo.ExpectedCalls = nil
+
+			tt.setupMocks()
+
+			result, err := service.GetAcceptanceCriteriaByID(tt.id)
+
+			if tt.expectedError != nil {
+				assert.Error(t, err)
+				assert.True(t, errors.Is(err, tt.expectedError))
+				assert.Nil(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+				assert.Equal(t, expectedAcceptanceCriteria.ID, result.ID)
+			}
+
+			mockAcceptanceCriteriaRepo.AssertExpectations(t)
+		})
+	}
+}
+
+func TestAcceptanceCriteriaService_DeleteAcceptanceCriteria(t *testing.T) {
+	mockAcceptanceCriteriaRepo := new(MockAcceptanceCriteriaRepository)
+	mockUserStoryRepo := new(MockUserStoryRepository)
+	mockUserRepo := new(MockUserRepository)
+
+	service := NewAcceptanceCriteriaService(mockAcceptanceCriteriaRepo, mockUserStoryRepo, mockUserRepo)
+
+	acceptanceCriteriaID := uuid.New()
+	userStoryID := uuid.New()
+	acceptanceCriteria := &models.AcceptanceCriteria{
+		ID:          acceptanceCriteriaID,
+		UserStoryID: userStoryID,
+		ReferenceID: "AC-001",
+		Description: "WHEN user clicks submit THEN system SHALL validate the form",
+	}
+
+	tests := []struct {
+		name          string
+		id            uuid.UUID
+		force         bool
+		setupMocks    func()
+		expectedError error
+	}{
+		{
+			name:  "successful deletion",
+			id:    acceptanceCriteriaID,
+			force: false,
+			setupMocks: func() {
+				mockAcceptanceCriteriaRepo.On("GetByID", acceptanceCriteriaID).Return(acceptanceCriteria, nil)
+				mockAcceptanceCriteriaRepo.On("HasRequirements", acceptanceCriteriaID).Return(false, nil)
+				mockAcceptanceCriteriaRepo.On("CountByUserStory", userStoryID).Return(int64(2), nil)
+				mockAcceptanceCriteriaRepo.On("Delete", acceptanceCriteriaID).Return(nil)
+			},
+			expectedError: nil,
+		},
+		{
+			name:  "acceptance criteria not found",
+			id:    acceptanceCriteriaID,
+			force: false,
+			setupMocks: func() {
+				mockAcceptanceCriteriaRepo.On("GetByID", acceptanceCriteriaID).Return(nil, repository.ErrNotFound)
+			},
+			expectedError: ErrAcceptanceCriteriaNotFound,
+		},
+		{
+			name:  "has requirements without force",
+			id:    acceptanceCriteriaID,
+			force: false,
+			setupMocks: func() {
+				mockAcceptanceCriteriaRepo.On("GetByID", acceptanceCriteriaID).Return(acceptanceCriteria, nil)
+				mockAcceptanceCriteriaRepo.On("HasRequirements", acceptanceCriteriaID).Return(true, nil)
+			},
+			expectedError: ErrAcceptanceCriteriaHasRequirements,
+		},
+		{
+			name:  "last acceptance criteria without force",
+			id:    acceptanceCriteriaID,
+			force: false,
+			setupMocks: func() {
+				mockAcceptanceCriteriaRepo.On("GetByID", acceptanceCriteriaID).Return(acceptanceCriteria, nil)
+				mockAcceptanceCriteriaRepo.On("HasRequirements", acceptanceCriteriaID).Return(false, nil)
+				mockAcceptanceCriteriaRepo.On("CountByUserStory", userStoryID).Return(int64(1), nil)
+			},
+			expectedError: ErrUserStoryMustHaveAcceptanceCriteria,
+		},
+		{
+			name:  "force deletion with requirements",
+			id:    acceptanceCriteriaID,
+			force: true,
+			setupMocks: func() {
+				mockAcceptanceCriteriaRepo.On("GetByID", acceptanceCriteriaID).Return(acceptanceCriteria, nil)
+				mockAcceptanceCriteriaRepo.On("Delete", acceptanceCriteriaID).Return(nil)
+			},
+			expectedError: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset mocks
+			mockAcceptanceCriteriaRepo.ExpectedCalls = nil
+
+			tt.setupMocks()
+
+			err := service.DeleteAcceptanceCriteria(tt.id, tt.force)
+
+			if tt.expectedError != nil {
+				assert.Error(t, err)
+				assert.True(t, errors.Is(err, tt.expectedError))
+			} else {
+				assert.NoError(t, err)
+			}
+
+			mockAcceptanceCriteriaRepo.AssertExpectations(t)
+		})
+	}
+}
+
+func TestAcceptanceCriteriaService_ValidateUserStoryHasAcceptanceCriteria(t *testing.T) {
+	mockAcceptanceCriteriaRepo := new(MockAcceptanceCriteriaRepository)
+	mockUserStoryRepo := new(MockUserStoryRepository)
+	mockUserRepo := new(MockUserRepository)
+
+	service := NewAcceptanceCriteriaService(mockAcceptanceCriteriaRepo, mockUserStoryRepo, mockUserRepo)
+
+	userStoryID := uuid.New()
+
+	tests := []struct {
+		name          string
+		userStoryID   uuid.UUID
+		setupMocks    func()
+		expectedError error
+	}{
+		{
+			name:        "user story has acceptance criteria",
+			userStoryID: userStoryID,
+			setupMocks: func() {
+				mockAcceptanceCriteriaRepo.On("CountByUserStory", userStoryID).Return(int64(2), nil)
+			},
+			expectedError: nil,
+		},
+		{
+			name:        "user story has no acceptance criteria",
+			userStoryID: userStoryID,
+			setupMocks: func() {
+				mockAcceptanceCriteriaRepo.On("CountByUserStory", userStoryID).Return(int64(0), nil)
+			},
+			expectedError: ErrUserStoryMustHaveAcceptanceCriteria,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset mocks
+			mockAcceptanceCriteriaRepo.ExpectedCalls = nil
+
+			tt.setupMocks()
+
+			err := service.ValidateUserStoryHasAcceptanceCriteria(tt.userStoryID)
+
+			if tt.expectedError != nil {
+				assert.Error(t, err)
+				assert.True(t, errors.Is(err, tt.expectedError))
+			} else {
+				assert.NoError(t, err)
+			}
+
+			mockAcceptanceCriteriaRepo.AssertExpectations(t)
+		})
+	}
+}


### PR DESCRIPTION
- Create AcceptanceCriteria service with CRUD operations
- Implement AcceptanceCriteria API endpoints
- Add validation for minimum one criteria per user story
- Implement AcceptanceCriteria deletion with requirement dependency handling
- Write unit and integration tests for AcceptanceCriteria operations
- Add proper reference ID generation with sequence-based approach
- Fix timestamp handling in BeforeCreate and BeforeUpdate hooks
- Update routes to include acceptance criteria endpoints
- Requirements: 3.1, 3.2, 3.3, 3.4